### PR TITLE
Add to_nested_h to arrays

### DIFF
--- a/lib/hash_helper.rb
+++ b/lib/hash_helper.rb
@@ -4,6 +4,7 @@ require_relative "hash_helper/version"
 require_relative "hash_helper/deep_invert"
 require_relative "hash_helper/deep_normalize"
 require_relative "hash_helper/percentage"
+require_relative "hash_helper/to_nested_h"
 
 module HashHelper
 end
@@ -12,4 +13,8 @@ class Hash
   include HashHelper::DeepInvert
   include HashHelper::DeepNormalize
   include HashHelper::Percentage
+end
+
+class Array
+  include HashHelper::ToNestedH
 end

--- a/lib/hash_helper/to_nested_h.rb
+++ b/lib/hash_helper/to_nested_h.rb
@@ -1,0 +1,32 @@
+module HashHelper
+  module ToNestedH
+    # Converts a nested array into a nested hash with a default value at leaf nodes.
+    # Each array in the input represents a level of keys in the resulting hash.
+    #
+    # @param [Object] value The default value to assign to the leaf nodes (default: nil).
+    # @return [Hash] A nested hash structure with the specified default value at the leaves.
+    #
+    # @example Single level array
+    #   [[:a, :b]].to_nested_h
+    #   # => {:a => nil, :b => nil}
+    #
+    # @example Two levels of nesting
+    #   [[:a, :b], [:x, :y]].to_nested_h(value: 0)
+    #   # => {:a => {:x => 0, :y => 0}, :b => {:x => 0, :y => 0}}
+    #
+    # @example Multiple levels of nesting
+    #   [[:a, :b], [:x, :y], [:m, :n]].to_nested_h(value: "leaf")
+    #   # => {
+    #   #   :a => { :x => { :m => "leaf", :n => "leaf" }, :y => { :m => "leaf", :n => "leaf" } },
+    #   #   :b => { :x => { :m => "leaf", :n => "leaf" }, :y => { :m => "leaf", :n => "leaf" } }
+    #   # }
+    def to_nested_h(value: nil)
+      return {} if empty?
+      return first.product([value]).to_h if size == 1
+
+      first.map do |key|
+        [key, self[1..].to_nested_h(value: value)]
+      end.to_h
+    end
+  end
+end

--- a/spec/hash_helper/to_nested_h_spec.rb
+++ b/spec/hash_helper/to_nested_h_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_support/core_ext/hash/deep_merge"
+require_relative "../../lib/hash_helper/to_nested_h"
+
+RSpec.describe "HashHelper::ToNestedH" do
+  describe '#to_nested_h' do
+    it 'converts a single level array into a flat hash with default nil values' do
+      arr = [[:a, :b]]
+      expect(arr.to_nested_h).to eq({ a: nil, b: nil })
+    end
+
+    it 'converts a single level array with a custom default value' do
+      arr = [[:a, :b]]
+      expect(arr.to_nested_h(value: 0)).to eq({ a: 0, b: 0 })
+    end
+
+    it 'handles two levels of nesting' do
+      arr = [[:a, :b], [:x, :y]]
+      expected = { a: { x: nil, y: nil }, b: { x: nil, y: nil } }
+      expect(arr.to_nested_h).to eq(expected)
+    end
+
+    it 'handles two levels of nesting with a custom default value' do
+      arr = [[:a, :b], [:x, :y]]
+      expected = { a: { x: 0, y: 0 }, b: { x: 0, y: 0 } }
+      expect(arr.to_nested_h(value: 0)).to eq(expected)
+    end
+
+    it 'handles three levels of nesting' do
+      arr = [[:a, :b], [:x, :y], [:m, :n]]
+      expected = {
+        a: { x: { m: nil, n: nil }, y: { m: nil, n: nil } },
+        b: { x: { m: nil, n: nil }, y: { m: nil, n: nil } }
+      }
+      expect(arr.to_nested_h).to eq(expected)
+    end
+
+    it 'handles three levels of nesting with a custom default value' do
+      arr = [[:a, :b], [:x, :y], [:m, :n]]
+      expected = {
+        a: { x: { m: 'leaf', n: 'leaf' }, y: { m: 'leaf', n: 'leaf' } },
+        b: { x: { m: 'leaf', n: 'leaf' }, y: { m: 'leaf', n: 'leaf' } }
+      }
+      expect(arr.to_nested_h(value: 'leaf')).to eq(expected)
+    end
+
+    it 'returns an empty hash when the array is empty' do
+      arr = []
+      expect(arr.to_nested_h).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new method, `to_nested_h`, to the Array class. The method allows converting an array of keys at multiple levels into a nested hash with a specified default value at its leaf nodes. It supports arrays of arbitrary depth and ensures consistent behavior, even for edge cases like empty arrays.

## Motivation
Currently, Array#to_h works well for flat key-value pair conversions but doesn't support nested structures. This method addresses that gap, enabling developers to build nested hash structures in a clean and intuitive way.

Given a multi-dimensional array, `to_nested_h` generates a nested hash where the keys are derived from each level of the array. Leaf nodes in the resulting hash are assigned a default value, which can be customized.

### Usage Examples
#### Single Level
```
[[:a, :b]].to_nested_h
# => { a: nil, b: nil }
```
#### Two Levels
```
[[:a, :b], [:x, :y]].to_nested_h(value: 0)
# => { a: { x: 0, y: 0 }, b: { x: 0, y: 0 } }
```
#### Multiple Levels
```
[[:a, :b], [:x, :y], [:m, :n]].to_nested_h(value: 'leaf')
# => {
#   a: { x: { m: 'leaf', n: 'leaf' }, y: { m: 'leaf', n: 'leaf' } },
#   b: { x: { m: 'leaf', n: 'leaf' }, y: { m: 'leaf', n: 'leaf' } }
# }
```
#### Empty Array
```
[].to_nested_h
# => {}
```